### PR TITLE
Add Order41 to the list of companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ List of Berlin companies using Elixir-Lang
 * [Mediteo](https://www.mediteo.com)
 * [Meltwater](https://www.meltwater.com)
 * [Nextjournal GmbH](https://nextjournal.com)
+* [Order41](https://order41.com)
 * [Priceline](https://www.priceline.com)
 * [Seatris.ai](https://seatris.com)
 * [solarisBank AG](https://www.solarisbank.com/en/)


### PR DESCRIPTION
Order41 is a Business to Business order platform.

The companies graphql api used for integrations is running on Elixir, Phoenix and Absinthe