### PR TITLE
Add Mitte to company list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ List of Berlin companies using Elixir-Lang
 * [Marley Spoon](https://marleyspoon.com/)
 * [Mediteo](https://www.mediteo.com)
 * [Meltwater](https://www.meltwater.com)
+* [Mitte](https://mitte.ai/)
 * [NewStore](https://www.newstore.com/)
 * [Nextjournal GmbH](https://nextjournal.com)
 * [NightWatch](https://nightwatch.io/)


### PR DESCRIPTION
## Summary

Adds Mitte to the Berlin companies using Elixir list.

## Evidence

- Mitte careers page: https://mitteai.notion.site/Careers-254f3cdf01fb80e38177d39bbb32c2e8
- The page lists open roles including Senior Full Stack Engineer (TypeScript, Go or Elixir) and Senior Backend Engineer (Elixir, Go).

## Validation

- Confirmed https://mitte.ai/ responds successfully.
- Checked the README entry is placed between Meltwater and NewStore in the existing company list.